### PR TITLE
syntax: add support for open struct

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -129,7 +129,7 @@ syn region   ocamlSig matchgroup=ocamlSigEncl start="\<sig\>" matchgroup=ocamlSi
 syn region   ocamlModSpec matchgroup=ocamlKeyword start="\<module\>" matchgroup=ocamlModule end="\<\u\(\w\|'\)*\>" contained contains=@ocamlAllErrs,ocamlComment skipwhite skipempty nextgroup=ocamlModTRWith,ocamlMPRestr
 
 " "open"
-syn region   ocamlNone matchgroup=ocamlKeyword start="\<open\>" matchgroup=ocamlModule end="\<\u\(\w\|'\)*\( *\. *\u\(\w\|'\)*\)*\>" contains=@ocamlAllErrs,ocamlComment
+syn match   ocamlKeyword "\<open\>" skipwhite skipempty nextgroup=ocamlFullMod
 
 " "include"
 syn match    ocamlKeyword "\<include\>" skipwhite skipempty nextgroup=ocamlModParam,ocamlFullMod


### PR DESCRIPTION
Since 4.08, in structures `open` behaves the same as include (from a syntax pov).