### PR TITLE
highlight indexing operators in mixfix position

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -228,7 +228,18 @@ syn match    ocamlStar         "*"
 syn match    ocamlAngle        "<"
 syn match    ocamlAngle        ">"
 " Custom indexing operators:
-syn match    ocamlIndexingOp   "\.[~?!:|&$%=>@^/*+-][~?!.:|&$%<=>@^*/+-]*\(()\|\[]\|{}\)\(<-\)\?"
+syn region   ocamlIndexing matchgroup=ocamlIndexingOp
+  \ start="\.[~?!:|&$%=>@^/*+-][~?!.:|&$%<=>@^*/+-]*\_s*("
+  \ end=")\(\_s*<-\)\?"
+  \ contains=ALLBUT,@ocamlContained,ocamlParenErr
+syn region   ocamlIndexing matchgroup=ocamlIndexingOp
+  \ start="\.[~?!:|&$%=>@^/*+-][~?!.:|&$%<=>@^*/+-]*\_s*\["
+  \ end="]\(\_s*<-\)\?"
+  \ contains=ALLBUT,@ocamlContained,ocamlBrackErr
+syn region   ocamlIndexing matchgroup=ocamlIndexingOp
+  \ start="\.[~?!:|&$%=>@^/*+-][~?!.:|&$%<=>@^*/+-]*\_s*{"
+  \ end="}\(\_s*<-\)\?"
+  \ contains=ALLBUT,@ocamlContained,ocamlBraceErr
 " Extension operators (has to be declared before regular infix operators):
 syn match    ocamlExtensionOp          "#[#~?!.:|&$%<=>@^*/+-]\+"
 " Infix and prefix operators:


### PR DESCRIPTION
Custom indexing operators were only highlighted in their “name” form (as in `( .![]<- ) a i v`), not in their “mixfix” form (as in `a.![i]<-v`). Moreover, no whitespace was tolerated before the `(`/`[`/`{` nor between the `)`/`]`/`}` and the `<-`, although OCaml allows it. Turns out it was easy to fix. So I fixed it.

Note that builtin indexers (`.()`, `.[]`, `.{}` and their `<-` counterpart), which are not operators, are still highlighted as keywords, as has always been the case.