### PR TITLE
Update errorformat for OCaml >= 4.09

### DIFF
--- a/compiler/ocaml.vim
+++ b/compiler/ocaml.vim
@@ -31,6 +31,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 CompilerSet errorformat =
+      \%EFile\ \"%f\"\\,\ lines\ %*\\d-%l\\,\ characters\ %c-%*\\d:,
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d:,
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d\ %.%#,
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ character\ %c:%m,


### PR DESCRIPTION
Even with `env OCAML_ERROR_STYLE=short`, OCaml can still produce errors with a range of lines, e.g.

    File "lib_term/analysis.ml", lines 16-39, characters 8-26:
    Error (warning 8): this pattern-matching is not exhaustive.

This might fix #35, but I've only tested it on one error so far.