### PR TITLE
new syntax group for start/end of ocamlEncl

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -81,10 +81,10 @@ syn cluster  ocamlContained contains=ocamlTodo,ocamlPreDef,ocamlModParam,ocamlMo
 
 
 " Enclosing delimiters
-syn region   ocamlEncl transparent matchgroup=ocamlKeyword start="(" matchgroup=ocamlKeyword end=")" contains=ALLBUT,@ocamlContained,ocamlParenErr
-syn region   ocamlEncl transparent matchgroup=ocamlKeyword start="{" matchgroup=ocamlKeyword end="}"  contains=ALLBUT,@ocamlContained,ocamlBraceErr
-syn region   ocamlEncl transparent matchgroup=ocamlKeyword start="\[" matchgroup=ocamlKeyword end="\]" contains=ALLBUT,@ocamlContained,ocamlBrackErr
-syn region   ocamlEncl transparent matchgroup=ocamlKeyword start="\[|" matchgroup=ocamlKeyword end="|\]" contains=ALLBUT,@ocamlContained,ocamlArrErr
+syn region   ocamlEncl transparent matchgroup=ocamlDelimiter start="(" matchgroup=ocamlDelimiter end=")" contains=ALLBUT,@ocamlContained,ocamlParenErr
+syn region   ocamlEncl transparent matchgroup=ocamlDelimiter start="{" matchgroup=ocamlDelimiter end="}"  contains=ALLBUT,@ocamlContained,ocamlBraceErr
+syn region   ocamlEncl transparent matchgroup=ocamlDelimiter start="\[" matchgroup=ocamlDelimiter end="\]" contains=ALLBUT,@ocamlContained,ocamlBrackErr
+syn region   ocamlEncl transparent matchgroup=ocamlDelimiter start="\[|" matchgroup=ocamlDelimiter end="|\]" contains=ALLBUT,@ocamlContained,ocamlArrErr
 
 
 " Comments
@@ -332,6 +332,7 @@ hi def link ocamlWith	   Include
 hi def link ocamlMTDef	   Include
 hi def link ocamlSigEncl	   ocamlModule
 hi def link ocamlStructEncl	   ocamlModule
+hi def link ocamlDelimiter    Delimiter
 
 hi def link ocamlScript	   Include
 


### PR DESCRIPTION
This patch introduces new syntax group `ocamlDelimiter` used for matchgroup of start/end of `ocamlEncl` (parentheses, ...). Previously, this was set to `ocamlKeyword` that many other keywords like `match` belong to. I think parentheses deserve their own syntax/highlight group and they should be linked to `Delimiter` by default. 

Please feel free to change the default link to `ocamlKeyword` if you think it's better to keep the original default value.