### PR TITLE
Do not not insert * when adding a line to a comment.

### DIFF
--- a/ftplugin/ocaml.vim
+++ b/ftplugin/ocaml.vim
@@ -38,7 +38,8 @@ let s:cposet=&cpoptions
 set cpo&vim
 
 " Comment string
-setlocal comments=sr:(*,ex:*)
+setlocal comments=sr:(*\ ,mb:\ ,ex:*)
+setlocal comments^=sr:(**,mb:\ \ ,ex:*)
 setlocal commentstring=(*%s*)
 
 " Add mappings, unless the user didn't want this.

--- a/ftplugin/ocaml.vim
+++ b/ftplugin/ocaml.vim
@@ -38,7 +38,7 @@ let s:cposet=&cpoptions
 set cpo&vim
 
 " Comment string
-setlocal comments=
+setlocal comments=sr:(*,ex:*)
 setlocal commentstring=(*%s*)
 
 " Add mappings, unless the user didn't want this.

--- a/indent/ocaml.vim
+++ b/indent/ocaml.vim
@@ -30,7 +30,7 @@ setlocal nosmartindent
 " Comment formatting
 if !exists("no_ocaml_comments")
  if (has("comments"))
-   setlocal comments=sr:(*,mb:*,ex:*)
+   setlocal comments=sr:(*,ex:*)
    setlocal fo=cqort
  endif
 endif

--- a/indent/ocaml.vim
+++ b/indent/ocaml.vim
@@ -30,7 +30,8 @@ setlocal nosmartindent
 " Comment formatting
 if !exists("no_ocaml_comments")
  if (has("comments"))
-   setlocal comments=sr:(*,ex:*)
+   setlocal comments=sr:(*\ ,mb:\ ,ex:*)
+   setlocal comments^=sr:(**,mb:\ \ ,ex:*)
    setlocal fo=cqort
  endif
 endif


### PR DESCRIPTION
Current tools like odoc and ocamlformat treat `*` as normal characters, not comment leaders, which can make them annoying.

With an empty leader continuing the comment from the first line doesn't preserve indentantion, this seems a problem with vim, for the rest of the cases it works as expected. Suggestion on how to work around this are very much welcome.

This setting can be overriden adding a line to the .vimrc / init.vim:
```
autocmd FileType ocaml setlocal comments=sr:(*,mb:*,ex:*)
```

I did not change the rest of `indent/ocaml.vim` due to my limited knowledge, it didn't seem to change the behaviour when I modified the section about comments. Let me know if a change is needed (and what kind of change should it be)