### PR TITLE
Use ocamlinterface (mli), ocamllex (mll) and menhir (mly) filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NeoBundleInstall ocaml/vim-ocaml'
 
 " or use NeoBundleLazy
 NeoBundleLazy 'rgrinberg/vim-ocaml', {'autoload' : {'filetypes' :
-    \ ['ocaml', 'ocamlinterface', 'dune', 'opam', 'oasis', 'omake', 'ocamlbuild_tags', 'sexplib']}}
+    \ ['ocaml', 'ocamlinterface', 'ocamllex', 'dune', 'opam', 'oasis', 'omake', 'ocamlbuild_tags', 'sexplib']}}
 ```
 
 ## History

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NeoBundleInstall ocaml/vim-ocaml'
 
 " or use NeoBundleLazy
 NeoBundleLazy 'rgrinberg/vim-ocaml', {'autoload' : {'filetypes' :
-    \ ['ocaml', 'dune', 'opam', 'oasis', 'omake', 'ocamlbuild_tags', 'sexplib']}}
+    \ ['ocaml', 'ocamlinterface', 'dune', 'opam', 'oasis', 'omake', 'ocamlbuild_tags', 'sexplib']}}
 ```
 
 ## History

--- a/ftdetect/ocaml.vim
+++ b/ftdetect/ocaml.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.ml,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.ml.cppo setf ocaml
+au BufNewFile,BufRead *.ml,*.mly,.ocamlinit,*.mlt,*.mlp,*.ml.cppo setf ocaml

--- a/ftdetect/ocaml.vim
+++ b/ftdetect/ocaml.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.ml,*.mli,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.mlip,*.mli.cppo,*.ml.cppo setf ocaml
+au BufNewFile,BufRead *.ml,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.ml.cppo setf ocaml

--- a/ftdetect/ocamlinterface.vim
+++ b/ftdetect/ocamlinterface.vim
@@ -1,0 +1,1 @@
+au BufNewFile,BufRead *.mli,*.mlip,*.mli.cppo setf ocamlinterface

--- a/ftdetect/ocamllex.vim
+++ b/ftdetect/ocamllex.vim
@@ -1,0 +1,1 @@
+au BufNewFile,BufRead *.mll setf ocamllex

--- a/ftplugin/ocamlinterface.vim
+++ b/ftplugin/ocamlinterface.vim
@@ -1,0 +1,12 @@
+" Language:    OCaml Interface
+" Maintainer:  vim-ocaml maintainers
+" URL:         http://www.github.com/ocaml/vim-ocaml
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+runtime! ftplugin/ocaml.vim
+runtime! ftplugin/ocaml_*.vim ftplugin/ocaml/*.vim
+
+" vim:sw=2 fdm=indent

--- a/ftplugin/ocamllex.vim
+++ b/ftplugin/ocamllex.vim
@@ -1,0 +1,12 @@
+" Language:    OCamlLex
+" Maintainer:  vim-ocaml maintainers
+" URL:         http://www.github.com/ocaml/vim-ocaml
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+runtime! ftplugin/ocaml.vim
+runtime! ftplugin/ocaml_*.vim ftplugin/ocaml/*.vim
+
+" vim:sw=2 fdm=indent


### PR DESCRIPTION
Some ocaml extensions share the same vim filetype. This is an issue when trying to enable [structural highlighting](https://github.com/ocaml/vim-ocaml/issues/11) using the official ocaml tree-sitter parsers: https://github.com/tree-sitter/tree-sitter-ocaml on [neovim](https://github.com/nvim-treesitter/nvim-treesitter/pull/472).

In tree-sitter-ocaml there are two parsers, oner for implementation files and another for interfaces. Initially there was a single, shared one but this caused conflicts in the grammar, so it was split. The current situation makes the nvim-plugin to interpret all `ocaml` files as implementation files, having a separate filetype for interfaces solves the issue.

This PR adds the new filetype and at the same time tries to maintain previous behaviour, so only external plugins and scripts depending on the `ocaml` filetype would be affected.

The change breaks current vim plugins that only expect a single filetype for all those kind of files, this includes ocaml/merlin, for example.

The plan to have a smooth transition is:
1. [ ] Gather plugins used by ocaml / vim users and warn users to change their vim scripts through a discuss.ocaml.org thread
2. [ ] Add support to all the new filetypes to those (neo)vim plugins
   - [ ] https://github.com/ocaml/merlin/pull/1340 
   - [x] https://github.com/neovim/nvim-lspconfig/pull/912
   - [x] https://github.com/dense-analysis/ale/pull/3732
   - ???
3. [ ] Add filetype detection for language plugins:
   - [ ] https://github.com/ocaml/vim-ocaml/pull/61
   - [ ] https://github.com/sheerun/vim-polyglot
   - ???
4. [ ] Upstream vim-ocaml changes to vim
   - [ ]  Update [filetype.lua](https://github.com/neovim/neovim/blob/master/runtime/lua/vim/filetype.lua) for neovim

The same situation happens with [ocamllex](https://github.com/atom-ocaml/tree-sitter-ocamllex) files. And although there's not a tree-sitter syntax for ocamlyacc/menhir, I've split it to the `menhir` filetype to avoid merlin from parsing them.