### PR TITLE
Put Constructor and Keyword delimiters in their own groups

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -84,10 +84,10 @@ syn cluster  ocamlContained contains=ocamlTodo,ocamlPreDef,ocamlModParam,ocamlMo
 
 
 " Enclosing delimiters
-syn region   ocamlEncl transparent matchgroup=ocamlKeyword start="(" matchgroup=ocamlKeyword end=")" contains=ALLBUT,@ocamlContained,ocamlParenErr
-syn region   ocamlEncl transparent matchgroup=ocamlKeyword start="{" matchgroup=ocamlKeyword end="}"  contains=ALLBUT,@ocamlContained,ocamlBraceErr
-syn region   ocamlEncl transparent matchgroup=ocamlKeyword start="\[" matchgroup=ocamlKeyword end="\]" contains=ALLBUT,@ocamlContained,ocamlBrackErr
-syn region   ocamlEncl transparent matchgroup=ocamlKeyword start="\[|" matchgroup=ocamlKeyword end="|\]" contains=ALLBUT,@ocamlContained,ocamlArrErr
+syn region   ocamlEncl transparent matchgroup=ocamlKeywordDelimiter start="(" matchgroup=ocamlKeywordDelimiter end=")" contains=ALLBUT,@ocamlContained,ocamlParenErr
+syn region   ocamlEncl transparent matchgroup=ocamlKeywordDelimiter start="{" matchgroup=ocamlKeywordDelimiter end="}"  contains=ALLBUT,@ocamlContained,ocamlBraceErr
+syn region   ocamlEncl transparent matchgroup=ocamlKeywordDelimiter start="\[" matchgroup=ocamlKeywordDelimiter end="\]" contains=ALLBUT,@ocamlContained,ocamlBrackErr
+syn region   ocamlEncl transparent matchgroup=ocamlKeywordDelimiter start="\[|" matchgroup=ocamlKeywordDelimiter end="|\]" contains=ALLBUT,@ocamlContained,ocamlArrErr
 
 
 " Comments
@@ -192,10 +192,10 @@ syn keyword  ocamlType     array bool char exn float format format4
 syn keyword  ocamlType     int int32 int64 lazy_t list nativeint option
 syn keyword  ocamlType     bytes string unit
 
-syn match    ocamlConstructor  "(\s*)"
-syn match    ocamlConstructor  "\[\s*\]"
-syn match    ocamlConstructor  "\[|\s*>|]"
-syn match    ocamlConstructor  "\[<\s*>\]"
+syn match    ocamlConstructorDelimiter  "(\s*)"
+syn match    ocamlConstructorDelimiter  "\[\s*\]"
+syn match    ocamlConstructorDelimiter  "\[|\s*>|]"
+syn match    ocamlConstructorDelimiter  "\[<\s*>\]"
 syn match    ocamlConstructor  "\u\(\w\|'\)*\>"
 
 " Polymorphic variants
@@ -339,11 +339,13 @@ hi def link ocamlStructEncl	   ocamlModule
 hi def link ocamlScript	   Include
 
 hi def link ocamlConstructor  Constant
+hi def link ocamlConstructorDelimiter  ocamlConstructor
 
 hi def link ocamlVal          Keyword
 hi def link ocamlModPreRHS    Keyword
 hi def link ocamlMPRestr2	   Keyword
 hi def link ocamlKeyword	   Keyword
+hi def link ocamlKeywordDelimiter	   ocamlKeyword
 hi def link ocamlMethod	   Include
 hi def link ocamlArrow	   Keyword
 hi def link ocamlKeyChar	   Keyword


### PR DESCRIPTION
This enables to selectively highlight Keyword and Constructor delimiters.

I find that highlighting brackets and parentheses just adds to visual clutter for no real benefit and it would be nice if you could disable them.