### PR TITLE
Support the quoted string with extension point shortcut.

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -168,6 +168,7 @@ syn match    ocamlMTDef "=\s*\w\(\w\|'\)*\>"hs=s+1,me=s+1 skipwhite skipempty ne
 
 " Quoted strings
 syn region ocamlString matchgroup=ocamlQuotedStringDelim start="{\z\([a-z_]*\)|" end="|\z1}" contains=@Spell
+syn region ocamlString matchgroup=ocamlQuotedStringDelim start="{%[a-z_]\+\(\.[a-z_]\+\)\?\( \z\([a-z_]\+\)\)\?|" end="|\z1}" contains=@Spell
 
 syn keyword  ocamlKeyword  and as assert class
 syn keyword  ocamlKeyword  constraint else


### PR DESCRIPTION
(This could be merged with the above line, but I think it would make the regex rather complex due to the mandatory space when both the extension and tag are present.)