### PR TITLE
Improve error format

### DIFF
--- a/compiler/ocaml.vim
+++ b/compiler/ocaml.vim
@@ -41,6 +41,8 @@ CompilerSet errorformat =
       \%Eocamlyacc:\ e\ -\ line\ %l\ of\ \"%f\"\\,\ %m,
       \%Wocamlyacc:\ w\ -\ %m,
       \%-Zmake%.%#,
+      \%C%*\\d\ \|%.%#,
+      \%C%p^%#,
       \%C%m,
       \%D%*\\a[%*\\d]:\ Entering\ directory\ `%f',
       \%X%*\\a[%*\\d]:\ Leaving\ directory\ `%f',

--- a/compiler/ocaml.vim
+++ b/compiler/ocaml.vim
@@ -54,7 +54,9 @@ CompilerSet errorformat =
       \%X%*\\a:\ Leaving\ directory\ '%f',
       \%DEntering\ directory\ '%f',
       \%XLeaving\ directory\ '%f',
-      \%DMaking\ %*\\a\ in\ %f
+      \%DMaking\ %*\\a\ in\ %f,
+      \%+G%m
+
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/compiler/ocaml.vim
+++ b/compiler/ocaml.vim
@@ -3,6 +3,7 @@
 " Maintainer:  Markus Mottl <markus.mottl@gmail.com>
 " URL:         https://github.com/ocaml/vim-ocaml
 " Last Change:
+"              2021 Nov 03 - Improved error format (Jules Aguillon)
 "              2020 Mar 28 - Improved error format (Thomas Leonard)
 "              2017 Nov 26 - Improved error format (Markus Mottl)
 "              2013 Aug 27 - Added a new OCaml error format (Markus Mottl)
@@ -35,6 +36,7 @@ CompilerSet errorformat =
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d:,
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d\ %.%#,
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ character\ %c:%m,
+      \%EFile\ \"%f\"\\,\ line\ %l:,
       \%+EReference\ to\ unbound\ regexp\ name\ %m,
       \%Eocamlyacc:\ e\ -\ line\ %l\ of\ \"%f\"\\,\ %m,
       \%Wocamlyacc:\ w\ -\ %m,


### PR DESCRIPTION
- One missing format for locations. `File "test.ml", line 1:`, used for signature mismatch errors.

- Skip highlighted code, which is otherwise joined to the error message.

- Match every other lines as "general messages" to make sure the quickfix window opens even if no messages matched.
