### PR TITLE
Small cleanups and fixes

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -38,9 +38,6 @@ syn case match
 " Access to the method of an object
 syn match    ocamlMethod       "#"
 
-" Script headers highlighted like comments
-syn match    ocamlComment   "^#!.*" contains=@Spell
-
 " Scripting directives
 syn match    ocamlScript "^#\<\(quit\|labels\|warnings\|warn_error\|directory\|remove_directory\|cd\|load\|load_rec\|use\|mod_use\|install_printer\|remove_printer\|require\|list\|ppx\|principal\|predicates\|rectypes\|thread\|trace\|untrace\|untrace_all\|print_depth\|print_length\|camlp4o\|camlp4r\|topfind_log\|topfind_verbose\)\>"
 
@@ -263,6 +260,9 @@ else
   syn match    ocamlKeyChar    "<-[~?!.:|&$%<=>@^*/+-]\@!"
 endif
 
+" Script shebang (has to be declared after operators)
+syn match    ocamlShebang       "^#!.*" contains=@Spell
+
 syn match    ocamlNumber        "-\=\<\d\(_\|\d\)*[l|L|n]\?\>"
 syn match    ocamlNumber        "-\=\<0[x|X]\(\x\|_\)\+[l|L|n]\?\>"
 syn match    ocamlNumber        "-\=\<0[o|O]\(\o\|_\)\+[l|L|n]\?\>"
@@ -313,6 +313,7 @@ hi def link ocamlCharErr	   Error
 hi def link ocamlErr	   Error
 
 hi def link ocamlComment	   Comment
+hi def link ocamlShebang    ocamlComment
 
 hi def link ocamlModPath	   Include
 hi def link ocamlObject	   Include

--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -47,15 +47,11 @@ syn match    ocamlScript "^#\<\(quit\|labels\|warnings\|warn_error\|directory\|r
 " lowercase identifier - the standard way to match
 syn match    ocamlLCIdentifier /\<\(\l\|_\)\(\w\|'\)*\>/
 
-syn match    ocamlKeyChar    "|"
-
 " Errors
 syn match    ocamlBraceErr   "}"
 syn match    ocamlBrackErr   "\]"
 syn match    ocamlParenErr   ")"
 syn match    ocamlArrErr     "|]"
-
-syn match    ocamlCommentErr "\*)"
 
 syn match    ocamlCountErr   "\<downto\>"
 syn match    ocamlCountErr   "\<to\>"
@@ -76,9 +72,8 @@ else
 endif
 
 " Some convenient clusters
-syn cluster  ocamlAllErrs contains=ocamlBraceErr,ocamlBrackErr,ocamlParenErr,ocamlCommentErr,ocamlCountErr,ocamlDoErr,ocamlDoneErr,ocamlEndErr,ocamlThenErr
-
-syn cluster  ocamlAENoParen contains=ocamlBraceErr,ocamlBrackErr,ocamlCommentErr,ocamlCountErr,ocamlDoErr,ocamlDoneErr,ocamlEndErr,ocamlThenErr
+syn cluster  ocamlAllErrs contains=@ocamlAENoParen,ocamlParenErr
+syn cluster  ocamlAENoParen contains=ocamlBraceErr,ocamlBrackErr,ocamlCountErr,ocamlDoErr,ocamlDoneErr,ocamlEndErr,ocamlThenErr
 
 syn cluster  ocamlContained contains=ocamlTodo,ocamlPreDef,ocamlModParam,ocamlModParam1,ocamlMPRestr,ocamlMPRestr1,ocamlMPRestr2,ocamlMPRestr3,ocamlModRHS,ocamlFuncWith,ocamlFuncStruct,ocamlModTypeRestr,ocamlModTRWith,ocamlWith,ocamlWithRest,ocamlModType,ocamlFullMod,ocamlVal
 
@@ -214,7 +209,7 @@ syn region   ocamlString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spel
 syn match    ocamlTopStop      ";;"
 
 syn match    ocamlAnyVar       "\<_\>"
-syn match    ocamlKeyChar      "|[^\]]"me=e-1
+syn match    ocamlKeyChar      "|]\@!"
 syn match    ocamlKeyChar      ";"
 syn match    ocamlKeyChar      "\~"
 syn match    ocamlKeyChar      "?"
@@ -274,8 +269,7 @@ syn match    ocamlNumber        "-\=\<0[b|B]\([01]\|_\)\+[l|L|n]\?\>"
 syn match    ocamlFloat         "-\=\<\d\(_\|\d\)*\.\?\(_\|\d\)*\([eE][-+]\=\d\(_\|\d\)*\)\=\>"
 
 " Labels
-syn match    ocamlLabel        "\~\(\l\|_\)\(\w\|'\)*"lc=1
-syn match    ocamlLabel        "?\(\l\|_\)\(\w\|'\)*"lc=1
+syn match    ocamlLabel        "[~?]\(\l\|_\)\(\w\|'\)*"lc=1
 syn region   ocamlLabel transparent matchgroup=ocamlLabel start="[~?](\(\l\|_\)\(\w\|'\)*"lc=2 end=")"me=e-1 contains=ALLBUT,@ocamlContained,ocamlParenErr
 
 
@@ -306,8 +300,6 @@ hi def link ocamlBraceErr	   Error
 hi def link ocamlBrackErr	   Error
 hi def link ocamlParenErr	   Error
 hi def link ocamlArrErr	   Error
-
-hi def link ocamlCommentErr   Error
 
 hi def link ocamlCountErr	   Error
 hi def link ocamlDoErr	   Error

--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -206,13 +206,14 @@ syn match    ocamlCharErr      "'\\\d\d'\|'\\\d'"
 syn match    ocamlCharErr      "'\\[^\'ntbr]'"
 syn region   ocamlString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@Spell
 
-syn match    ocamlTopStop      ";;"
-
 syn match    ocamlAnyVar       "\<_\>"
 syn match    ocamlKeyChar      "|]\@!"
 syn match    ocamlKeyChar      ";"
 syn match    ocamlKeyChar      "\~"
 syn match    ocamlKeyChar      "?"
+
+" NOTE: for correct precedence, the rule for ";;" must come after that for ";"
+syn match    ocamlTopStop      ";;"
 
 "" Operators
 

--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -79,10 +79,10 @@ syn cluster  ocamlContained contains=ocamlTodo,ocamlPreDef,ocamlModParam,ocamlMo
 
 
 " Enclosing delimiters
-syn region   ocamlEncl transparent matchgroup=ocamlKeywordDelimiter start="(" matchgroup=ocamlKeywordDelimiter end=")" contains=ALLBUT,@ocamlContained,ocamlParenErr
-syn region   ocamlEncl transparent matchgroup=ocamlKeywordDelimiter start="{" matchgroup=ocamlKeywordDelimiter end="}"  contains=ALLBUT,@ocamlContained,ocamlBraceErr
-syn region   ocamlEncl transparent matchgroup=ocamlKeywordDelimiter start="\[" matchgroup=ocamlKeywordDelimiter end="\]" contains=ALLBUT,@ocamlContained,ocamlBrackErr
-syn region   ocamlEncl transparent matchgroup=ocamlKeywordDelimiter start="\[|" matchgroup=ocamlKeywordDelimiter end="|\]" contains=ALLBUT,@ocamlContained,ocamlArrErr
+syn region   ocamlNone transparent matchgroup=ocamlEncl start="(" matchgroup=ocamlEncl end=")" contains=ALLBUT,@ocamlContained,ocamlParenErr
+syn region   ocamlNone transparent matchgroup=ocamlEncl start="{" matchgroup=ocamlEncl end="}"  contains=ALLBUT,@ocamlContained,ocamlBraceErr
+syn region   ocamlNone transparent matchgroup=ocamlEncl start="\[" matchgroup=ocamlEncl end="\]" contains=ALLBUT,@ocamlContained,ocamlBrackErr
+syn region   ocamlNone transparent matchgroup=ocamlEncl start="\[|" matchgroup=ocamlEncl end="|\]" contains=ALLBUT,@ocamlContained,ocamlArrErr
 
 
 " Comments
@@ -188,10 +188,10 @@ syn keyword  ocamlType     array bool char exn float format format4
 syn keyword  ocamlType     int int32 int64 lazy_t list nativeint option
 syn keyword  ocamlType     bytes string unit
 
-syn match    ocamlConstructorDelimiter  "(\s*)"
-syn match    ocamlConstructorDelimiter  "\[\s*\]"
-syn match    ocamlConstructorDelimiter  "\[|\s*>|]"
-syn match    ocamlConstructorDelimiter  "\[<\s*>\]"
+syn match    ocamlEmptyConstructor  "(\s*)"
+syn match    ocamlEmptyConstructor  "\[\s*\]"
+syn match    ocamlEmptyConstructor  "\[|\s*>|]"
+syn match    ocamlEmptyConstructor  "\[<\s*>\]"
 syn match    ocamlConstructor  "\u\(\w\|'\)*\>"
 
 " Polymorphic variants
@@ -332,13 +332,12 @@ hi def link ocamlStructEncl	   ocamlModule
 hi def link ocamlScript	   Include
 
 hi def link ocamlConstructor  Constant
-hi def link ocamlConstructorDelimiter  ocamlConstructor
+hi def link ocamlEmptyConstructor  ocamlConstructor
 
 hi def link ocamlVal          Keyword
 hi def link ocamlModPreRHS    Keyword
 hi def link ocamlMPRestr2	   Keyword
 hi def link ocamlKeyword	   Keyword
-hi def link ocamlKeywordDelimiter	   ocamlKeyword
 hi def link ocamlMethod	   Include
 hi def link ocamlArrow	   Keyword
 hi def link ocamlKeyChar	   Keyword

--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -261,7 +261,7 @@ else
 endif
 
 " Script shebang (has to be declared after operators)
-syn match    ocamlShebang       "^#!.*" contains=@Spell
+syn match    ocamlShebang       "\%1l^#!.*$"
 
 syn match    ocamlNumber        "-\=\<\d\(_\|\d\)*[l|L|n]\?\>"
 syn match    ocamlNumber        "-\=\<0[x|X]\(\x\|_\)\+[l|L|n]\?\>"


### PR DESCRIPTION
What the title says. The first 2 commits are just simplifying or removing dead code. The second 2 are fixing 2 issues with highlighting.

1. It was intended that the `ocamlTopStop` matchgroup allowed the user to highlight `;;` differently than `;`, however that was not working; this is now fixed.
2. The code for highlighting shebangs wasn’t working anymore (because of a precedence conflict with newer code); this is now fixed, plus, the new `ocamlShebang` matchgroup allows the user to style shebangs to her liking (by default they are styled like comments, as before).