### PR TITLE
Fix `:Opam` with local switches

### DIFF
--- a/doc/opam.txt
+++ b/doc/opam.txt
@@ -7,7 +7,9 @@ This plugin is only available if 'compatible' is not set.
 
 COMMANDS                                        *:opam*
 
-:Opam {version}          Set the current OCaml version to {version}.
+:Opam                    With no argument. Refresh the environment using |opam env|.
+
+:Opam {version}          Set the current switch to {version}.
 
 ABOUT                                           *opam-about*
 

--- a/plugin/opam.vim
+++ b/plugin/opam.vim
@@ -17,6 +17,7 @@ function! opam#eval_env()
     let var = split(split(cmd, ";")[0], "=")
     execute 'let $' . var[0] . " = " . var[1]
   endfor
+  let g:opam_current_compiler = opam#compiler_version()
 endfunction
 
 function! opam#switch(ocaml_version)
@@ -24,7 +25,6 @@ function! opam#switch(ocaml_version)
   let success = empty(matchstr(res, 'ERROR'))
   if success
     call opam#eval_env()
-    let g:opam_current_compiler = opam#compiler_version()
   endif
   return success
 endfunction
@@ -67,7 +67,8 @@ function! s:Opam(bang,...) abort
   elseif len(a:000) > 0
     call opam#cmd_switch(a:1)
   else
-    call opam#cmd_switch(opam#compiler_version())
+    call opam#eval_env()
+    echomsg "Using " . g:opam_current_compiler
   end
 endfunction
 


### PR DESCRIPTION
The previous change to :Opam carelessly used the equivalent of:

    opam switch set $(opam switch show)

Which have an unexpected behavior in case of local or linked switches.
Now using a read only command equivalent to the intended:

    eval $(opam env --readonly)