### PR TITLE
RFC: Make sure Opam's environment is consistent

### DIFF
--- a/doc/opam.txt
+++ b/doc/opam.txt
@@ -11,6 +11,20 @@ COMMANDS                                        *:opam*
 
 :Opam {version}          Set the current switch to {version}.
 
+CONFIGURATION                                    *opam-configuration*
+
+                                                 *g:opam_set_switch*
+
+If this variable is set to a non-zero value, |:Opam| will set the |$OPAMSWITCH|
+environment variable. This variable will make sure that every |opam| commands
+run from inside Vim will continue to act on the same switch even if the
+selected switch is changed.
+This also mean that selecting a different switch without using the |:Opam|
+command will not take effect in this instance of Vim.
+Defaults to |0|.
+
+  let g:opam_set_switch = 1
+
 ABOUT                                           *opam-about*
 
 Grab the latest version or report a bug on GitHub:

--- a/ftplugin/ocaml.vim
+++ b/ftplugin/ocaml.vim
@@ -641,6 +641,11 @@ endfunction
   nnoremap <silent> <Plug>OCamlPrintType :<C-U>call Ocaml_print_type("normal")<CR>
   xnoremap <silent> <Plug>OCamlPrintType :<C-U>call Ocaml_print_type("visual")<CR>`<
 
+" Make sure the environment is consistent
+if !exists('g:opam_current_compiler')
+  call opam#eval_env()
+endif
+
 let &cpoptions=s:cposet
 unlet s:cposet
 

--- a/plugin/opam.vim
+++ b/plugin/opam.vim
@@ -11,6 +11,7 @@ let g:loaded_opam = 1
 " Utility {{{1
 
 function! opam#eval_env()
+  unlet $OPAMSWITCH
   let opam_eval = system("opam env --readonly --set-switch --set-root")
   if v:shell_error
     return 0


### PR DESCRIPTION
This ensures that every Opam commands are in the same environment, the
'*PATH' variable are consistent with the switch used by commands in
':term' or ':!'.

Additionally, running a command directly won't differ from running it
through 'opam exec'.

The inconvenient is that the switch used might not be the selected
switch. Running 'opam switch set' won't affect subsequent commands at all.

The statusline function is already compatible with this: if ':Opam' is
ever called, it won't query `opam switch set` again, so it can be
simplified.

This is a draft PR because it might change how people use this plugin and Opam. For example, when using a shell along side vim (not inside) to run Opam commands, commands run inside Vim will be in the wrong environment.
I have seen `opam exec -- dune` commands inside a Makefile, some might have `opam exec -- ocamlformat` as `formatprg`. These might be called from inside Vim anyway.

If this makes sense, I should add an option to disable this (perhaps even disabled by default).