### PR TITLE
Fix several linting issues related to the new linter

### DIFF
--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -169,7 +169,7 @@ syn region ocamlString matchgroup=ocamlQuotedStringDelim start="{%[a-z_]\+\(\.[a
 
 syn keyword  ocamlKeyword  and as assert class
 syn keyword  ocamlKeyword  else
-syn keyword  ocamlKeyword  external fun
+syn keyword  ocamlKeyword  external
 syn keyword  ocamlKeyword  in inherit initializer
 syn keyword  ocamlKeyword  lazy let match
 syn keyword  ocamlKeyword  method new
@@ -180,6 +180,13 @@ syn keyword  ocamlKeyword  virtual when while with
 " Keywords which are handled by the type linter:
 "     as (within a type equation)
 "     constraint exception mutable nonrec of private type
+
+" The `fun` keyword has special treatment because of the syntax `fun … : t -> e`
+" where `->` ends the type context rather than being part of it; to handle that,
+" we blacklist the ocamlTypeAnnot matchgroup, and we plug ocamlFunTypeAnnot
+" instead (later in this file, by using containedin=ocamlFun):
+syn region ocamlFun matchgroup=ocamlKeyword start='\<fun\>' matchgroup=ocamlArrow end='->'
+\ contains=ALLBUT,@ocamlContained,ocamlArrow,ocamlInfixOp,ocamlTypeAnnot
 
 if exists("ocaml_revised")
   syn keyword  ocamlKeyword  do value
@@ -498,6 +505,15 @@ syn region ocamlTypeAnnot matchgroup=ocamlKeyChar start=":\(>\|\_s*type\>\|[>:=]
 \ matchgroup=NONE end="\(=\|:>\)\@="
 \ contains=@ocamlTypeExpr,ocamlComment,ocamlPpx
 hi link ocamlTypeAnnot ocamlTypeCatchAll
+
+" Type annotation that gives the return type of a `fun` keyword
+" (the type context is ended by `->`)
+syn cluster ocamlTypeContained add=ocamlFunTypeAnnot
+syn region ocamlFunTypeAnnot contained containedin=ocamlFun
+\ matchgroup=ocamlKeyChar start=":"
+\ matchgroup=NONE end="\(->\)\@="
+\ contains=@ocamlTypeExpr,ocamlComment,ocamlPpx
+hi link ocamlFunTypeAnnot ocamlTypeCatchAll
 
 " Module paths (including functors) in types.
 " NOTE: This rule must occur after the rule for ocamlTypeSumDecl as it must take

--- a/syntax/ocaml.vim
+++ b/syntax/ocaml.vim
@@ -440,7 +440,7 @@ syn region ocamlTypeSumDecl contained
 \ matchgroup=ocamlTypeSumConstr start="\<\u\(\w\|'\)*\>"
 \ matchgroup=ocamlTypeSumConstr start="\<false\>" start="\<true\>"
 \ matchgroup=ocamlTypeSumConstr start="(\_s*)" start="\[\_s*]" start="(\_s*::\_s*)"
-\ matchgroup=NONE end="\(\<type\>\|\<exception\>\|\<val\>\|\<module\>\|\<class\>\|\<method\>\|\<constraint\>\|\<inherit\>\|\<object\>\|\<struct\>\|\<open\>\|\<include\>\|\<let\>\|\<external\>\|\<in\>\|\<end\>\|)\|]\|}\|;\|;;\)\@="
+\ matchgroup=NONE end="\(\<type\>\|\<exception\>\|\<val\>\|\<module\>\|\<class\>\|\<method\>\|\<constraint\>\|\<inherit\>\|\<object\>\|\<struct\>\|\<open\>\|\<include\>\|\<let\>\|\<external\>\|\<in\>\|\<end\>\|)\|]\|}\|;\|;;\|=\)\@="
 \ matchgroup=NONE end="\(\<and\>\)\@="
 \ contains=ocamlTypeSumBar,ocamlTypeSumConstr,ocamlTypeSumAnnot,ocamlTypeBlank,ocamlComment,ocamlPpx
 hi link ocamlTypeSumDecl ocamlTypeCatchAll

--- a/type-linter-notes.md
+++ b/type-linter-notes.md
@@ -65,9 +65,10 @@ spot dangling closing parentheses).
 **more closing delimiters for sum type definitions**
   + → the additional closing delimiters for `type`
   + `and`
+  + `=` (because of `exception E = F`)
 
 **more closing delimiters for `of` and `:` in sum type definitions**
-  + → the additional closing delimiters for sum type definitions
+  + → the additional closing delimiters for sum type definitions (excepted `=`)
   + `|`
 
 **more closing delimiters for `:` and `: type` and `:>`**

--- a/type-linter-test.ml
+++ b/type-linter-test.ml
@@ -139,7 +139,8 @@
   exception E
   exception E of int
   exception E : int -> exn
-  exception E' = E (* FIXME *)
+  exception E' = E
+  exception F = Stdlib.Not_found
   (* local exceptions *)
   let _ = let exception E in ()
   let _ = let exception E of int * int in ()

--- a/type-linter-test.ml
+++ b/type-linter-test.ml
@@ -359,5 +359,6 @@
   let f = ( fun x -> x : int -> int  )  (* x is an expr of type int *)
   let f (=) x = ( x = x : int -> bool ) (* totally irrealistic case *)
 
-  (* FIXME the unsolvable problem *)
+  (* return type of a `fun` *)
   let _ = fun x : int -> 42 (* int is the return type, `->` ends the type! *)
+  let _ = fun (f : int -> int) : int -> 42


### PR DESCRIPTION
Each of the two commits fixes one the following issues (which were both noted as FIXMEs in the test file).

1. `exception E = F` : the equal sign was wrongly shown as an error; the fix is easy. This addresses a portion of #84.
2. `fun ... : t -> e` : the type context was wrongly running over `->` ; the fix introduces a little extra bit of complexity (`fun` is now the start of a region rather than just a keyword) but it is simpler than I anticipated (thanks to the `containedin=` feature of Vim). This closes #86.

Remaining issues:

- the test file has one remaining FIXME (but of much lesser importance, it is more a feature wish than an actual issue): `class ['a] myclass ...` where we’d like the type variable to be highlighted as such;
- #84 has one more issue: `(module M)` used as a type expression. 