### PR TITLE
[opam] remove `opamKeyword2` 

### DIFF
--- a/syntax/opam.vim
+++ b/syntax/opam.vim
@@ -14,12 +14,16 @@ endif
 syn keyword opamKeyword1 author
 syn keyword opamKeyword1 authors
 syn keyword opamKeyword1 available
+syn keyword opamKeyword1 bug-reports
+syn keyword opamKeyword1 build
+syn keyword opamKeyword1 build-env
 syn keyword opamKeyword1 conflict-class
 syn keyword opamKeyword1 conflicts
 syn keyword opamKeyword1 depends
 syn keyword opamKeyword1 depexts
 syn keyword opamKeyword1 depopts
 syn keyword opamKeyword1 description
+syn keyword opamKeyword1 dev-repo
 syn keyword opamKeyword1 doc
 syn keyword opamKeyword1 extra-files
 syn keyword opamKeyword1 features
@@ -31,7 +35,10 @@ syn keyword opamKeyword1 license
 syn keyword opamKeyword1 maintainer
 syn keyword opamKeyword1 messages
 syn keyword opamKeyword1 name
+syn keyword opamKeyword1 opam-version
 syn keyword opamKeyword1 patches
+syn keyword opamKeyword1 pin-depends
+syn keyword opamKeyword1 post-messages
 syn keyword opamKeyword1 remove
 syn keyword opamKeyword1 run-test
 syn keyword opamKeyword1 setenv
@@ -40,7 +47,6 @@ syn keyword opamKeyword1 synopsis
 syn keyword opamKeyword1 syntax
 syn keyword opamKeyword1 tags
 syn keyword opamKeyword1 version
-syn match opamKeyword2 "\v(bug-reports|post-messages|opam-version|dev-repo|pin-depends|build)"
 
 syn keyword opamTodo FIXME NOTE NOTES TODO XXX contained
 syn match opamComment "#.*$" contains=opamTodo,@Spell
@@ -48,11 +54,10 @@ syn match opamOperator ">\|<\|=\|<=\|>="
 
 syn region opamInterpolate start=/%{/ end=/}%/ contained
 syn region opamString start=/"/ end=/"/ contains=opamInterpolate
-syn region opamSeq start=/\[/ end=/\]/ contains=ALLBUT,opamKeyword1,opamKeyword2
-syn region opamExp start=/{/ end=/}/ contains=ALLBUT,opamKeyword1,opamKeyword2
+syn region opamSeq start=/\[/ end=/\]/ contains=ALLBUT,opamKeyword1
+syn region opamExp start=/{/ end=/}/ contains=ALLBUT,opamKeyword1
 
 hi link opamKeyword1 Keyword
-hi link opamKeyword2 Keyword
 
 hi link opamString String
 hi link opamExp Function


### PR DESCRIPTION
There is no difference between `opamKeyword1` and `opamKeyword2`.
related https://github.com/ocaml/vim-ocaml/pull/73#discussion_r801810302