### PR TITLE
[opam] accept keywords with dash

### DIFF
--- a/syntax/opam.vim
+++ b/syntax/opam.vim
@@ -11,6 +11,7 @@ endif
 
 " need %{vars}%
 " env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]
+syn iskeyword a-z,A-Z,-
 syn keyword opamKeyword1 author
 syn keyword opamKeyword1 authors
 syn keyword opamKeyword1 available


### PR DESCRIPTION
found the answer to https://github.com/ocaml/vim-ocaml/pull/73#discussion_r801810302 : `-` wasn't accepted in keywords. So setting it with `iskeyword` defined as `[a-z-]`