### PR TITLE
Opam: No startup call when g:opam_set_switch is disabled

### DIFF
--- a/doc/opam.txt
+++ b/doc/opam.txt
@@ -25,6 +25,14 @@ Defaults to |0|.
 
   let g:opam_set_switch = 1
 
+                                                 *g:opam_init_env*
+
+If this variable is set to a non-zero value, Opam's environment will be
+refreshed when the plugin is loaded for the first time.
+This is equivalent to calling |:Opam| when first opening an OCaml file.
+
+  let g:opam_init_env = 1
+
 ABOUT                                           *opam-about*
 
 Grab the latest version or report a bug on GitHub:

--- a/ftplugin/ocaml.vim
+++ b/ftplugin/ocaml.vim
@@ -642,7 +642,7 @@ endfunction
   xnoremap <silent> <Plug>OCamlPrintType :<C-U>call Ocaml_print_type("visual")<CR>`<
 
 " Make sure the environment is consistent
-if !exists('g:opam_current_compiler')
+if exists('g:opam_set_switch') && g:opam_set_switch != 0
   call opam#eval_env()
 endif
 

--- a/ftplugin/ocaml.vim
+++ b/ftplugin/ocaml.vim
@@ -642,7 +642,7 @@ endfunction
   xnoremap <silent> <Plug>OCamlPrintType :<C-U>call Ocaml_print_type("visual")<CR>`<
 
 " Make sure the environment is consistent
-if !exists('g:opam_current_compiler') && exists('g:opam_set_switch') && g:opam_set_switch != 0
+if !exists('g:opam_current_compiler') && exists('g:opam_init_env') && g:opam_init_env != 0
   call opam#eval_env()
 endif
 

--- a/ftplugin/ocaml.vim
+++ b/ftplugin/ocaml.vim
@@ -642,7 +642,7 @@ endfunction
   xnoremap <silent> <Plug>OCamlPrintType :<C-U>call Ocaml_print_type("visual")<CR>`<
 
 " Make sure the environment is consistent
-if exists('g:opam_set_switch') && g:opam_set_switch != 0
+if !exists('g:opam_current_compiler') && exists('g:opam_set_switch') && g:opam_set_switch != 0
   call opam#eval_env()
 endif
 


### PR DESCRIPTION
This was part of e775524 but was intended to be disabled when `g:opam_set_switch` isn't set.