### PR TITLE
Improve error format

### DIFF
--- a/compiler/ocaml.vim
+++ b/compiler/ocaml.vim
@@ -32,7 +32,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 CompilerSet errorformat =
-      \%EFile\ \"%f\"\\,\ lines\ %*\\d-%l\\,\ characters\ %c-%*\\d:,
+      \%EFile\ \"%f\"\\,\ lines\ %l-%*\\d\\,\ characters\ %c-%*\\d:,
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d:,
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d\ %.%#,
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ character\ %c:%m,

--- a/compiler/ocaml.vim
+++ b/compiler/ocaml.vim
@@ -11,17 +11,6 @@
 " Marc Weber's comments:
 " Setting makeprg doesn't make sense, because there is ocamlc, ocamlopt,
 " ocamake and whatnot. So which one to use?
-"
-" This error format was moved from ftplugin/ocaml.vim to this file,
-" because ftplugin is the wrong file to set an error format
-" and the error format itself is annoying because it joins many lines in this
-" error case:
-"
-"    Error: The implementation foo.ml does not match the interface foo.cmi:
-"    Modules do not match case.
-"
-" So having it here makes people opt-in
-
 
 if exists("current_compiler")
     finish
@@ -51,10 +40,17 @@ CompilerSet errorformat +=
       \%+EReference\ to\ unbound\ regexp\ name\ %m,
       \%Eocamlyacc:\ e\ -\ line\ %l\ of\ \"%f\"\\,\ %m,
       \%Wocamlyacc:\ w\ -\ %m,
-      \%-Zmake%.%#,
-      \%C%*\\d\ \|%.%#,
-      \%C%p^%#,
-      \%C%m,
+      \%-Zmake%.%#
+
+if get(g:, "ocaml_compiler_compact_messages", v:true)
+  CompilerSet errorformat +=
+        \%C%*\\d\ \|%.%#,
+        \%C%p^%#,
+        \%C%m
+endif
+
+CompilerSet errorformat +=
+      \%Z,
       \%D%*\\a[%*\\d]:\ Entering\ directory\ `%f',
       \%X%*\\a[%*\\d]:\ Leaving\ directory\ `%f',
       \%D%*\\a:\ Entering\ directory\ `%f',
@@ -65,8 +61,12 @@ CompilerSet errorformat +=
       \%X%*\\a:\ Leaving\ directory\ '%f',
       \%DEntering\ directory\ '%f',
       \%XLeaving\ directory\ '%f',
-      \%DMaking\ %*\\a\ in\ %f,
-      \%+G%m
+      \%DMaking\ %*\\a\ in\ %f
+
+if get(g:, "ocaml_compiler_compact_messages", v:true)
+  CompilerSet errorformat +=
+        \%+G%m
+endif
 
 
 let &cpo = s:cpo_save

--- a/compiler/ocaml.vim
+++ b/compiler/ocaml.vim
@@ -3,6 +3,7 @@
 " Maintainer:  Markus Mottl <markus.mottl@gmail.com>
 " URL:         https://github.com/ocaml/vim-ocaml
 " Last Change:
+"              2023 Nov 24 - Improved error format (Samuel Hym)
 "              2021 Nov 03 - Improved error format (Jules Aguillon)
 "              2020 Mar 28 - Improved error format (Thomas Leonard)
 "              2017 Nov 26 - Improved error format (Markus Mottl)

--- a/compiler/ocaml.vim
+++ b/compiler/ocaml.vim
@@ -31,10 +31,21 @@ let current_compiler = "ocaml"
 let s:cpo_save = &cpo
 set cpo&vim
 
-CompilerSet errorformat =
-      \%EFile\ \"%f\"\\,\ lines\ %l-%*\\d\\,\ characters\ %c-%*\\d:,
-      \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d:,
-      \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d\ %.%#,
+" Patch 8.2.4329 introduces %e and %k as end line and end column positions
+
+if has('patch-8.2.4329')
+  CompilerSet errorformat =
+        \%EFile\ \"%f\"\\,\ lines\ %l-%e\\,\ characters\ %c-%k:,
+        \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%k:,
+        \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%k\ %.%#,
+else
+  CompilerSet errorformat =
+        \%EFile\ \"%f\"\\,\ lines\ %l-%*\\d\\,\ characters\ %c-%*\\d:,
+        \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d:,
+        \%EFile\ \"%f\"\\,\ line\ %l\\,\ characters\ %c-%*\\d\ %.%#,
+endif
+
+CompilerSet errorformat +=
       \%EFile\ \"%f\"\\,\ line\ %l\\,\ character\ %c:%m,
       \%EFile\ \"%f\"\\,\ line\ %l:,
       \%+EReference\ to\ unbound\ regexp\ name\ %m,

--- a/doc/ocaml.txt
+++ b/doc/ocaml.txt
@@ -9,4 +9,12 @@ highlighted. You can turn on highlighting of operators by defining:
 
   let g:ocaml_highlight_operators = 1
 
+                                           *g:ocaml_compiler_compact_messages*
+
+By default the output of the OCaml compiler is filtered to keep only the
+location and message by the compiler plugin. You can keep the full multi-line
+messages as displayed by the compiler by defining:
+
+  let g:ocaml_compiler_compact_messages = 0
+
  vim:tw=78:et:ft=help:norl:


### PR DESCRIPTION
This PR does three things for the compiler plugin:

- it fixes an issue and uses modern `'efm'` features (end line and end column),
- it adds an option to keep full compiler messages in the quickfix list, so that reading the output of the compiler can be done entirely using the quickfix window (so the compiler can run in background somehow...)
- it provides a sensible value (`ocamlc`) for `makeprg` and the probably most commonly-useful values (`ocamlopt` and `dune`) in comments, to guide users but also so that the `vim-dispatch` plugin will automatically pick up that compiler plugin for commands starting with `ocamlc`, `ocamlopt` and `dune`...