### PR TITLE
ftdetect: Detect `.eliom` and `.eliomi` file extensions

### DIFF
--- a/ftdetect/ocaml.vim
+++ b/ftdetect/ocaml.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead *.ml,*.mli,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.mlip,*.mli.cppo,*.ml.cppo setf ocaml
+au BufNewFile,BufRead *.ml,*.mli,*.mll,*.mly,.ocamlinit,*.mlt,*.mlp,*.mlip,*.mli.cppo,*.ml.cppo,*.eliom,*.eliomi setf ocaml


### PR DESCRIPTION
These extensions are often used when writing [Eliom](https://github.com/ocsigen/eliom) applications.